### PR TITLE
Handle alternate specs in spec/lib

### DIFF
--- a/plugin/rake.vim
+++ b/plugin/rake.vim
@@ -344,10 +344,14 @@ function! s:buffer_related() dict abort
     return s:project().first_file(
           \'test/'.bare.'_test.rb',
           \'spec/'.bare.'_spec.rb',
+          \'test/lib/'.bare.'_test.rb',
+          \'spec/lib/'.bare.'_spec.rb',
           \'test/unit/'.bare.'_test.rb',
           \'spec/unit/'.bare.'_spec.rb')
   elseif self.name() =~# '^\(test\|spec\)/.*_\1\.rb$'
-    return 'lib/'.self.name()[5:-9].'.rb'
+    return s:project().first_file(
+      \'lib/'.self.name()[5:-9].'.rb',
+      \self.name()[5:-9].'.rb')
   elseif self.name() ==# 'Gemfile'
     return 'Gemfile.lock'
   elseif self.name() ==# 'Gemfile.lock'


### PR DESCRIPTION
spec/lib seems popular for rails apps, but some gems have specs there too (pg, fog, rake-compiler).

So this patch searches both: spec and spec/lib

A related pull request: https://github.com/guard/guard-rspec/pull/96

I tested the patch by alternate file switching on various combinations:

```
project/lib/foo.rb -> [ project/spec/foo.rb, project/spec/lib/foo.rb]
project/lib/bar/foo.rb -> [ project/spec/bar/foo.rb, project/spec/lib/bar/foo.rb]
```

Seems to work both ways in all cases.

Thanks for your legendary work on vim plugins!
