### PR TITLE
Check filetype before sending Rake autocmd

### DIFF
--- a/plugin/rake.vim
+++ b/plugin/rake.vim
@@ -133,7 +133,7 @@ function! s:Detect(path)
       let b:rake_root = dir
     endif
   endif
-  if exists('b:rake_root')
+  if exists('b:rake_root') && &ft == "ruby"
     silent doautocmd User Rake
   endif
 endfunction


### PR DESCRIPTION
I ran into a obscure bug using vim-rake in a go project that used a Rakefile to preform various tasks. I have my own vim script that overrides `:A` to alternate between tests and implementation for go files but the `A` command was being overridden by vim-rake because I had a Rakefile in my root.

I'm not sure if this is the best way to fix it but this did work for me.
