### PR TITLE
Support the test_*.rb naming convention for related files

### DIFF
--- a/plugin/rake.vim
+++ b/plugin/rake.vim
@@ -395,11 +395,12 @@ function! s:buffer_related() dict abort
           \'spec/unit/'.bare.'_spec.rb',
           \'spec/unit/'.dirname.'/spec_'.basename.'.rb')
   elseif self.name() =~# '^\(test\|spec\)/.*_\1\.rb$'
+    let bare = s:sub(self.name(), '^(test|spec)/(unit/)?(.*)_\1\.rb$', '\3.rb')
     return s:project().first_file(
-      \'lib/'.self.name()[5:-9].'.rb',
-      \self.name()[5:-9].'.rb')
+      \'lib/'.bare,
+      \bare)
   elseif self.name() =~# '^\(test\|spec\)/.*\1_.*\.rb$'
-    let bare = s:sub(self.name(), '^(test|spec)/(.*)\1_(.*\.rb)$', '\3\4')
+    let bare = s:sub(self.name(), '^(test|spec)/(unit/)?(.*)\1_(.*\.rb)$', '\3\4')
     return s:project().first_file(
       \'lib/'.bare,
       \bare)


### PR DESCRIPTION
Add support for the test_*.rb naming convention as described in http://guides.rubygems.org/patterns/#consistent-naming

Additionally, I fixed switching from test files that are in the unit subdirectory.
