### PR TITLE
Push lib into the loadpath

### DIFF
--- a/plugin/rake.vim
+++ b/plugin/rake.vim
@@ -13,7 +13,7 @@ if !exists('g:dispatch_compilers')
 endif
 let g:dispatch_compilers['bundle exec'] = ''
 let g:dispatch_compilers['ruby bin/rake'] = 'rake'
-let g:dispatch_compilers['ruby -Itest'] = 'rubyunit'
+let g:dispatch_compilers['ruby -I lib:test'] = 'rubyunit'
 
 " Utility {{{1
 


### PR DESCRIPTION
It seems to be common not to push `lib` into the loadpath while using `minitest` or `testunit`.

And not to lean on each of the project maintainers to include:

``` ruby
$: << File.expand_path("lib")
```

in their `test/test_helper.rb`. I propose injecting `lib` into the load-path by default
