### PR TITLE
Add minitest projections

### DIFF
--- a/plugin/rake.vim
+++ b/plugin/rake.vim
@@ -102,9 +102,14 @@ augroup END
 let s:projections = {
       \ '*': {},
       \ 'lib/*.rb': {'type': 'lib', 'alternate': [
+      \   'test/test_{}.rb', 'test/lib/test_{}.rb', 'test/unit/test_{}.rb',
       \   'test/{}_test.rb', 'test/lib/{}_test.rb', 'test/unit/{}_test.rb',
       \   'spec/{}_spec.rb', 'spec/lib/{}_spec.rb', 'spec/unit/{}_spec.rb']},
       \ 'test/test_helper.rb': {'type': 'test'},
+      \ 'test/minitest_helper.rb': {'type': 'test'},
+      \ 'test/test_*.rb': {
+      \   'type': 'test',
+      \   'alternate': 'lib/{}.rb'},
       \ 'test/*_test.rb': {
       \   'type': 'test',
       \   'alternate': 'lib/{}.rb'},


### PR DESCRIPTION
When creating a new gem with `bundle gem new-gem`, minitest is the default
framework, and tests comes with the pattern:

    test/test_name_of_unit.rb

This PR adds the projections necessary to use `:A` and friends with the generated files.