### PR TITLE
Ruby C extension files support

### DIFF
--- a/doc/rake.txt
+++ b/doc/rake.txt
@@ -71,6 +71,13 @@ COMMANDS                                        *rake-commands*
 Set g:rake_legacy to 1 to enable the old, legacy R command variants.  This
 option will eventually be removed.
 
+                                                *rake-ruby-c-extensions*
+This plugin supports Ruby C extension files usually located under ext/.
+For those C files 'path' is enhanced with correct Ruby include directory.
+With this you can use |i_CTRL-X_CTRL-I| completion and |[i|, |[d| families of
+mappings and commands on all the macros and functions provided by ruby.h
+header file.
+
 ABOUT                                           *rake-about*
 
 Grab the latest version or report a bug on GitHub:


### PR DESCRIPTION
Hi,
this PR brings Ruby C extension files support discussed in #24.

I think all the suggestions from there are implemented.

Additionally I've checked the Ruby "logic" (fetching Ruby include directory) on multiple Linux machines and even on Windows (Cygwin). Ruby code has been tweaked a bit to support older ruby versions (1.8.7).

Please let me know if you have any feedback on this!
Thanks