### PR TITLE
Fix 'path' and 'tags' appending

### DIFF
--- a/plugin/rake.vim
+++ b/plugin/rake.vim
@@ -339,8 +339,8 @@ augroup rake_path
         \ endif
   autocmd User Rake
         \ if &filetype ==# 'c' || &filetype ==# 'cpp' |
-        \   let &l:path .= ',' . escape(s:project().ruby_include_path(),', ') |
-        \   let &l:tags .= ',' . escape(s:project().ruby_include_path().'/tags',', ') |
+        \   let &l:path = &path . ',' . escape(s:project().ruby_include_path(),', ') |
+        \   let &l:tags = &tags . ',' . escape(s:project().ruby_include_path().'/tags',', ') |
         \ endif
 augroup END
 


### PR DESCRIPTION
Commit c38ed340c43ad82b148001f97c61520adaf40ef5 broke `'path'` and `'tag'` in C buffers.

&l.path will shadow &path for the buffer, but is empty at first.