### PR TITLE
Assume Rails only when `app` directory present

### DIFF
--- a/plugin/rake.vim
+++ b/plugin/rake.vim
@@ -77,7 +77,7 @@ function! s:find_root(path) abort
   let previous = ''
   while root !=# previous && root !~# '^\%(\a\+:\)\=/*$\|^\.$'
     if s:has(root, 'Rakefile') || (s:has(root, 'lib') && s:has(root, 'Gemfile'))
-      if s:has(root, 'config/environment.rb')
+      if s:has(root, 'config/environment.rb') && s:has(root, 'app')
         return ''
       else
         return root


### PR DESCRIPTION
Today I have tried to use vim again instead of RubyMine (after about 5 years).
I was very surprised when I realized that `vim-rails` activates 
in my very custom `dry-system`-based ruby application, 
but does not work at all (because no Rails in that app).
 
I ensured that I have `vim-rake` installed. 
I have updated `vim-rake`. It did not work.
I have updated `vim-rails`. It did not work.
Then I have removed `vim-rails`. And `vim-rake` still did not work
Nothing helped. 

Then I found issue #28 opened more than 3 years ago. 

I thought: “Ouch! It might be very difficult to fix such error! A lot of time passed, with no luck and no fix”. 
Then I looked at the issue tpope/vim-rails#391 mentioned in #28. 
And then looked at the commit tpope/vim-rails@c7aeb5b, closed that issue.

I haven’t written any code in VimL before 30 minutes ago (except some copy-paste from internets to my `.vimrc`), so I am not sure, that I did the fix right way. Could you assist me? 

I haven’t checked it’s behaviour in any Rails app also 
(since I have no rails apps or rails libs installed here), 
sorry. 